### PR TITLE
Added missing parameter 'flags'

### DIFF
--- a/onkyo2mqtt.py
+++ b/onkyo2mqtt.py
@@ -67,7 +67,7 @@ def msghandler(mqc,userdata,msg):
 	except Exception as e:
 		logging.warning("Error processing message %s" % e)
 
-def connecthandler(mqc,userdata,rc):
+def connecthandler(mqc,userdata,flags,rc):
     logging.info("Connected to MQTT broker with rc=%d" % (rc))
     mqc.subscribe(topic+"set/#",qos=0)
     mqc.subscribe(topic+"command",qos=0)


### PR DESCRIPTION
As of commit https://github.com/eclipse/paho.mqtt.python/commit/713955bd6123059044d928526d01d3aa4f8b16ca a fourth parameter is required in the on_connect callback. Otherwise this will result in:
`TypeError: connecthandler() takes exactly 3 arguments (4 given)`